### PR TITLE
update logging to print the state type name

### DIFF
--- a/fsm/fsm.go
+++ b/fsm/fsm.go
@@ -89,7 +89,7 @@ func (d fsmHandler) Plan(events []statemachine.Event, user interface{}) (interfa
 	}
 	_, skipHandler := err.(ErrSkipHandler)
 	if err != nil && !skipHandler {
-		log.Errorf("Executing event planner failed: %+v", err)
+		log.Errorf("Executing event planner failed for %s: %+v", d.stateType.Name(), err)
 		return nil, 1, nil
 	}
 	currentState := userValue.Elem().FieldByName(string(d.stateKeyField)).Interface()


### PR DESCRIPTION
This helps debugging In situations where multiple state machines are running, i.e. data transfer manager and filecoin retrieval manager